### PR TITLE
Zero digits tincycrypt handling

### DIFF
--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -430,7 +430,7 @@ bitcount_t uECC_vli_numBits(const uECC_word_t *vli)
 
 	digit = vli[num_digits - 1];
 #if defined __GNUC__ || defined __clang__ || defined __CC_ARM
-	i = uECC_WORD_BITS - __builtin_clz(digit);
+	i = (digit == 0)? 0 : uECC_WORD_BITS - __builtin_clz(digit);
 #else
 	for (i = 0; digit; ++i) {
 		digit >>= 1;


### PR DESCRIPTION
This is a possible situation for passed user data, that was not handled properly. `__builtin_clz` with a zero results in an undefined behaviour.
Please note that this PR is based on https://github.com/PelionIoT/pelion-crypto/pull/4.
Please only review the last commit.