### PR TITLE
Fix parallel makes with the platform_fault feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ PREFIX=mbedtls_
 PROGRAMS_DIR=./programs
 TESTS_DIR=./tests
 
+ifdef TEST_FAULT
+FAULT_OBJ ?= tests/data_files/platform_fault.o
+else
+FAULT_OBJ ?=
+endif
+
 # Check test environment. If ../library is available then Mbed TLS is used.
 # Otherwise Mbed OS environment is used.
 DIR_FOR_MBED_TLS_ENV=./library
@@ -27,14 +33,17 @@ all: programs tests
 
 no_test: programs
 
-programs: lib
+programs: lib $(FAULT_OBJ)
 	$(MAKE) -C $(PROGRAMS_DIR)
 
 lib:
 	$(MAKE) -C $(LIBRARY_DIR)
 
-tests: lib
+tests: lib $(FAULT_OBJ)
 	$(MAKE) -C $(TESTS_DIR)
+
+tests/data_files/platform_fault.o:
+	$(MAKE) -C tests ../tests/data_files/platform_fault.o
 
 ifndef WINDOWS
 install: no_test

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -2,10 +2,10 @@
 # To compile on SunOS: add "-lsocket -lnsl" to LDFLAGS
 # To compile with PKCS11: add "-lpkcs11-helper" to LDFLAGS
 ifdef TEST_FAULT
-PROG_FAULT_OBJ ?= ../tests/data_files/platform_fault.o
+FAULT_OBJ ?= ../tests/data_files/platform_fault.o
 CFLAGS	?= -O2 -I../tests/data_files
 else
-PROG_FAULT_OBJ ?=
+FAULT_OBJ ?=
 CFLAGS	?= -O2
 endif
 
@@ -112,205 +112,205 @@ all: $(APPS)
 $(DEP):
 	$(MAKE) -C ../library
 
-aes/aescrypt2$(EXEXT): aes/aescrypt2.c $(DEP) $(PROG_FAULT_OBJ)
+aes/aescrypt2$(EXEXT): aes/aescrypt2.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    aes/aescrypt2.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) aes/aescrypt2.c  $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) aes/aescrypt2.c  $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-aes/crypt_and_hash$(EXEXT): aes/crypt_and_hash.c $(DEP) $(PROG_FAULT_OBJ)
+aes/crypt_and_hash$(EXEXT): aes/crypt_and_hash.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    aes/crypt_and_hash.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) aes/crypt_and_hash.c $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) aes/crypt_and_hash.c $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-hash/hello$(EXEXT): hash/hello.c $(DEP) $(PROG_FAULT_OBJ)
+hash/hello$(EXEXT): hash/hello.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    hash/hello.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) hash/hello.c       $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) hash/hello.c       $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-hash/generic_sum$(EXEXT): hash/generic_sum.c $(DEP) $(PROG_FAULT_OBJ)
+hash/generic_sum$(EXEXT): hash/generic_sum.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    hash/generic_sum.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) hash/generic_sum.c $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) hash/generic_sum.c $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/dh_client$(EXEXT): pkey/dh_client.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/dh_client$(EXEXT): pkey/dh_client.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/dh_client.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/dh_client.c   $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/dh_client.c   $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/dh_genprime$(EXEXT): pkey/dh_genprime.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/dh_genprime$(EXEXT): pkey/dh_genprime.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/dh_genprime.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/dh_genprime.c $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/dh_genprime.c $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/dh_server$(EXEXT): pkey/dh_server.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/dh_server$(EXEXT): pkey/dh_server.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/dh_server.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/dh_server.c   $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/dh_server.c   $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/ecdh_curve25519$(EXEXT): pkey/ecdh_curve25519.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/ecdh_curve25519$(EXEXT): pkey/ecdh_curve25519.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/ecdh_curve25519.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/ecdh_curve25519.c   $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/ecdh_curve25519.c   $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/ecdsa$(EXEXT): pkey/ecdsa.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/ecdsa$(EXEXT): pkey/ecdsa.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/ecdsa.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/ecdsa.c       $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/ecdsa.c       $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/gen_key$(EXEXT): pkey/gen_key.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/gen_key$(EXEXT): pkey/gen_key.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/gen_key.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/gen_key.c   $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/gen_key.c   $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/key_app$(EXEXT): pkey/key_app.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/key_app$(EXEXT): pkey/key_app.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/key_app.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/key_app.c   $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/key_app.c   $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/key_app_writer$(EXEXT): pkey/key_app_writer.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/key_app_writer$(EXEXT): pkey/key_app_writer.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/key_app_writer.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/key_app_writer.c   $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/key_app_writer.c   $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/mpi_demo$(EXEXT): pkey/mpi_demo.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/mpi_demo$(EXEXT): pkey/mpi_demo.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/mpi_demo.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/mpi_demo.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/mpi_demo.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/pk_decrypt$(EXEXT): pkey/pk_decrypt.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/pk_decrypt$(EXEXT): pkey/pk_decrypt.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/pk_decrypt.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/pk_decrypt.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/pk_decrypt.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/pk_encrypt$(EXEXT): pkey/pk_encrypt.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/pk_encrypt$(EXEXT): pkey/pk_encrypt.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/pk_encrypt.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/pk_encrypt.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/pk_encrypt.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/pk_sign$(EXEXT): pkey/pk_sign.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/pk_sign$(EXEXT): pkey/pk_sign.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/pk_sign.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/pk_sign.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/pk_sign.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/pk_verify$(EXEXT): pkey/pk_verify.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/pk_verify$(EXEXT): pkey/pk_verify.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/pk_verify.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/pk_verify.c  $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/pk_verify.c  $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/rsa_genkey$(EXEXT): pkey/rsa_genkey.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/rsa_genkey$(EXEXT): pkey/rsa_genkey.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/rsa_genkey.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_genkey.c  $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_genkey.c  $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/rsa_sign$(EXEXT): pkey/rsa_sign.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/rsa_sign$(EXEXT): pkey/rsa_sign.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/rsa_sign.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_sign.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_sign.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/rsa_verify$(EXEXT): pkey/rsa_verify.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/rsa_verify$(EXEXT): pkey/rsa_verify.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/rsa_verify.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_verify.c  $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_verify.c  $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/rsa_sign_pss$(EXEXT): pkey/rsa_sign_pss.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/rsa_sign_pss$(EXEXT): pkey/rsa_sign_pss.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/rsa_sign_pss.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_sign_pss.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_sign_pss.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/rsa_verify_pss$(EXEXT): pkey/rsa_verify_pss.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/rsa_verify_pss$(EXEXT): pkey/rsa_verify_pss.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/rsa_verify_pss.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_verify_pss.c  $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_verify_pss.c  $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/rsa_decrypt$(EXEXT): pkey/rsa_decrypt.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/rsa_decrypt$(EXEXT): pkey/rsa_decrypt.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/rsa_decrypt.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_decrypt.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_decrypt.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-pkey/rsa_encrypt$(EXEXT): pkey/rsa_encrypt.c $(DEP) $(PROG_FAULT_OBJ)
+pkey/rsa_encrypt$(EXEXT): pkey/rsa_encrypt.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    pkey/rsa_encrypt.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_encrypt.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_encrypt.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-random/gen_entropy$(EXEXT): random/gen_entropy.c $(DEP) $(PROG_FAULT_OBJ)
+random/gen_entropy$(EXEXT): random/gen_entropy.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    random/gen_entropy.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) random/gen_entropy.c $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) random/gen_entropy.c $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-random/gen_random_havege$(EXEXT): random/gen_random_havege.c $(DEP) $(PROG_FAULT_OBJ)
+random/gen_random_havege$(EXEXT): random/gen_random_havege.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    random/gen_random_havege.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) random/gen_random_havege.c $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) random/gen_random_havege.c $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-random/gen_random_ctr_drbg$(EXEXT): random/gen_random_ctr_drbg.c $(DEP) $(PROG_FAULT_OBJ)
+random/gen_random_ctr_drbg$(EXEXT): random/gen_random_ctr_drbg.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    random/gen_random_ctr_drbg.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) random/gen_random_ctr_drbg.c $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) random/gen_random_ctr_drbg.c $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-ssl/dtls_client$(EXEXT): ssl/dtls_client.c $(DEP) $(PROG_FAULT_OBJ)
+ssl/dtls_client$(EXEXT): ssl/dtls_client.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    ssl/dtls_client.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/dtls_client.c  $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/dtls_client.c  $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-ssl/dtls_server$(EXEXT): ssl/dtls_server.c $(DEP) $(PROG_FAULT_OBJ)
+ssl/dtls_server$(EXEXT): ssl/dtls_server.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    ssl/dtls_server.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/dtls_server.c  $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/dtls_server.c  $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-ssl/ssl_client1$(EXEXT): ssl/ssl_client1.c $(DEP) $(PROG_FAULT_OBJ)
+ssl/ssl_client1$(EXEXT): ssl/ssl_client1.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    ssl/ssl_client1.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_client1.c  $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_client1.c  $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-ssl/ssl_client2$(EXEXT): ssl/ssl_client2.c ssl/query_config.c $(DEP) $(PROG_FAULT_OBJ)
+ssl/ssl_client2$(EXEXT): ssl/ssl_client2.c ssl/query_config.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    ssl/ssl_client2.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_client2.c ssl/query_config.c $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_client2.c ssl/query_config.c $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-ssl/ssl_server$(EXEXT): ssl/ssl_server.c $(DEP) $(PROG_FAULT_OBJ)
+ssl/ssl_server$(EXEXT): ssl/ssl_server.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    ssl/ssl_server.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_server.c   $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_server.c   $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-ssl/ssl_server2$(EXEXT): ssl/ssl_server2.c ssl/query_config.c $(DEP) $(PROG_FAULT_OBJ)
+ssl/ssl_server2$(EXEXT): ssl/ssl_server2.c ssl/query_config.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    ssl/ssl_server2.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_server2.c ssl/query_config.c $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_server2.c ssl/query_config.c $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-ssl/ssl_fork_server$(EXEXT): ssl/ssl_fork_server.c $(DEP) $(PROG_FAULT_OBJ)
+ssl/ssl_fork_server$(EXEXT): ssl/ssl_fork_server.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    ssl/ssl_fork_server.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_fork_server.c   $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_fork_server.c   $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-ssl/ssl_pthread_server$(EXEXT): ssl/ssl_pthread_server.c $(DEP) $(PROG_FAULT_OBJ)
+ssl/ssl_pthread_server$(EXEXT): ssl/ssl_pthread_server.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    ssl/ssl_pthread_server.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_pthread_server.c   $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) -lpthread  $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_pthread_server.c   $(FAULT_OBJ) $(LOCAL_LDFLAGS) -lpthread  $(LDFLAGS) -o $@
 
-ssl/ssl_mail_client$(EXEXT): ssl/ssl_mail_client.c $(DEP) $(PROG_FAULT_OBJ)
+ssl/ssl_mail_client$(EXEXT): ssl/ssl_mail_client.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    ssl/ssl_mail_client.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_mail_client.c   $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_mail_client.c   $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-ssl/mini_client$(EXEXT): ssl/mini_client.c $(DEP) $(PROG_FAULT_OBJ)
+ssl/mini_client$(EXEXT): ssl/mini_client.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    ssl/mini_client.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/mini_client.c   $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/mini_client.c   $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-test/benchmark$(EXEXT): test/benchmark.c $(DEP) $(PROG_FAULT_OBJ)
+test/benchmark$(EXEXT): test/benchmark.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    test/benchmark.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/benchmark.c   $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/benchmark.c   $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-test/cpp_dummy_build$(EXEXT): test/cpp_dummy_build.cpp $(DEP) $(PROG_FAULT_OBJ)
+test/cpp_dummy_build$(EXEXT): test/cpp_dummy_build.cpp $(DEP) $(FAULT_OBJ)
 	echo "  CXX   test/cpp_dummy_build.cpp"
-	$(CXX) $(LOCAL_CXXFLAGS) $(CXXFLAGS) test/cpp_dummy_build.cpp   $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CXX) $(LOCAL_CXXFLAGS) $(CXXFLAGS) test/cpp_dummy_build.cpp   $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-test/selftest$(EXEXT): test/selftest.c $(DEP) $(PROG_FAULT_OBJ)
+test/selftest$(EXEXT): test/selftest.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    test/selftest.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/selftest.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/selftest.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-test/udp_proxy$(EXEXT): test/udp_proxy.c $(DEP) $(PROG_FAULT_OBJ)
+test/udp_proxy$(EXEXT): test/udp_proxy.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    test/udp_proxy.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/udp_proxy.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/udp_proxy.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-test/zeroize$(EXEXT): test/zeroize.c $(DEP) $(PROG_FAULT_OBJ)
+test/zeroize$(EXEXT): test/zeroize.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    test/zeroize.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/zeroize.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/zeroize.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-test/query_compile_time_config$(EXEXT): test/query_compile_time_config.c ssl/query_config.c $(DEP) $(PROG_FAULT_OBJ)
+test/query_compile_time_config$(EXEXT): test/query_compile_time_config.c ssl/query_config.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    test/query_compile_time_config.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/query_compile_time_config.c ssl/query_config.c $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/query_compile_time_config.c ssl/query_config.c $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-util/pem2der$(EXEXT): util/pem2der.c $(DEP) $(PROG_FAULT_OBJ)
+util/pem2der$(EXEXT): util/pem2der.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    util/pem2der.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) util/pem2der.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) util/pem2der.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-util/strerror$(EXEXT): util/strerror.c $(DEP) $(PROG_FAULT_OBJ)
+util/strerror$(EXEXT): util/strerror.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    util/strerror.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) util/strerror.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) util/strerror.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-x509/cert_app$(EXEXT): x509/cert_app.c $(DEP) $(PROG_FAULT_OBJ)
+x509/cert_app$(EXEXT): x509/cert_app.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    x509/cert_app.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) x509/cert_app.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) x509/cert_app.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-x509/cert_write$(EXEXT): x509/cert_write.c $(DEP) $(PROG_FAULT_OBJ)
+x509/cert_write$(EXEXT): x509/cert_write.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    x509/cert_write.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) x509/cert_write.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) x509/cert_write.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-x509/crl_app$(EXEXT): x509/crl_app.c $(DEP) $(PROG_FAULT_OBJ)
+x509/crl_app$(EXEXT): x509/crl_app.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    x509/crl_app.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) x509/crl_app.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) x509/crl_app.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-x509/cert_req$(EXEXT): x509/cert_req.c $(DEP) $(PROG_FAULT_OBJ)
+x509/cert_req$(EXEXT): x509/cert_req.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    x509/cert_req.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) x509/cert_req.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) x509/cert_req.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-x509/req_app$(EXEXT): x509/req_app.c $(DEP) $(PROG_FAULT_OBJ)
+x509/req_app$(EXEXT): x509/req_app.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    x509/req_app.c"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) x509/req_app.c    $(PROG_FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) x509/req_app.c    $(FAULT_OBJ) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ../tests/data_files/platform_fault.o:
 	$(MAKE) -C ../tests data_files/platform_fault.o

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,7 +3,7 @@
 # To compile with PKCS11: add "-lpkcs11-helper" to LDFLAGS
 
 ifdef TEST_FAULT
-FAULT_OBJ ?= data_files/platform_fault.o
+FAULT_OBJ ?= ../tests/data_files/platform_fault.o
 CFLAGS	?= -O2 -Idata_files
 else
 CFLAGS	?= -O2
@@ -131,7 +131,7 @@ $(BINARIES): %$(EXEXT): %.c $(DEP) $(FAULT_OBJ)
 	echo "  CC    $<"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $(FAULT_OBJ) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-data_files/platform_fault.o: data_files/platform_fault.c
+../tests/data_files/platform_fault.o: data_files/platform_fault.c
 	echo "  CC    $<"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -c $< -o $@
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1867,7 +1867,7 @@ component_test_platform_fault_ood () {
     cp -rf ./tests/data_files/platform_fault.* ./ood_platform_fault
 
     msg "build: default config + platform fault out of directory"
-    make TEST_FAULT=1 FAULT_OBJ="../ood_platform_fault/platform_fault.o" PROG_FAULT_OBJ="../ood_platform_fault/platform_fault.o" CFLAGS="-I$(pwd)/ood_platform_fault"
+    make TEST_FAULT=1 FAULT_OBJ="$(pwd)/ood_platform_fault/platform_fault.o" CFLAGS="-I$(pwd)/ood_platform_fault"
 
     msg "test: default config + platform fault out of directory"
     if_build_succeeded make test


### PR DESCRIPTION
There was an issue when running parallel make - both the programs makefile and tests makefile tried to build it at the same time, so if one of them did it and started linking with it and the second one then did the build - a linking with a partially created file would occur.
This PR fixes it by introducing a call to build it in the first place (as a requirement for tests and programs), and also simplifies the number of arguments needed for an out of directory build.