### PR TITLE
Reduce oid binary size

### DIFF
--- a/library/oid.c
+++ b/library/oid.c
@@ -583,7 +583,7 @@ FN_OID_GET_OID_BY_ATTR1(mbedtls_oid_get_oid_by_ec_grp, oid_ecp_grp_t, oid_ecp_gr
 #endif /* MBEDTLS_ECP_C */
 #endif
 
-#if defined(MBEDTLS_CIPHER_C)
+#if defined(MBEDTLS_CIPHER_C) && defined(MBEDTLS_PKCS5_C)
 /*
  * For PKCS#5 PBES2 encryption algorithm
  */
@@ -610,9 +610,9 @@ static const oid_cipher_alg_t oid_cipher_alg[] =
 
 FN_OID_TYPED_FROM_ASN1(oid_cipher_alg_t, cipher_alg, oid_cipher_alg)
 FN_OID_GET_ATTR1(mbedtls_oid_get_cipher_alg, oid_cipher_alg_t, cipher_alg, mbedtls_cipher_type_t, cipher_alg)
-#endif /* MBEDTLS_CIPHER_C */
+#endif /* MBEDTLS_CIPHER_C && MBEDTLS_PKCS5_C */
 
-#if defined(MBEDTLS_MD_C)
+#if (defined(MBEDTLS_RSA_C) && defined(MBEDTLS_PKCS1_V15)) || defined(MBEDTLS_PKCS11_C) || defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT)
 /*
  * For digestAlgorithm
  */
@@ -677,6 +677,9 @@ FN_OID_TYPED_FROM_ASN1(oid_md_alg_t, md_alg, oid_md_alg)
 FN_OID_GET_ATTR1(mbedtls_oid_get_md_alg, oid_md_alg_t, md_alg, mbedtls_md_type_t, md_alg)
 FN_OID_GET_OID_BY_ATTR1(mbedtls_oid_get_oid_by_md, oid_md_alg_t, oid_md_alg, mbedtls_md_type_t, md_alg)
 
+#endif /* (MBEDTLS_RSA_C && MBEDTLS_PKCS1_V15) || MBEDTLS_PKCS11_C || MBEDTLS_X509_RSASSA_PSS_SUPPORT */
+
+#if defined(MBEDTLS_PKCS5_C)
 /*
  * For HMAC digestAlgorithm
  */
@@ -721,7 +724,7 @@ static const oid_md_hmac_t oid_md_hmac[] =
 
 FN_OID_TYPED_FROM_ASN1(oid_md_hmac_t, md_hmac, oid_md_hmac)
 FN_OID_GET_ATTR1(mbedtls_oid_get_md_hmac, oid_md_hmac_t, md_hmac, mbedtls_md_type_t, md_hmac)
-#endif /* MBEDTLS_MD_C */
+#endif /* MBEDTLS_PKCS5_C */
 
 #if defined(MBEDTLS_PKCS12_C)
 /*

--- a/library/oid.c
+++ b/library/oid.c
@@ -177,6 +177,7 @@ typedef struct {
     const char          *short_name;
 } oid_x520_attr_t;
 
+#if defined(MBEDTLS_X509_CRT_WRITE_C) || !defined(MBEDTLS_X509_REMOVE_INFO)
 static const oid_x520_attr_t oid_x520_attr_type[] =
 {
     {
@@ -263,6 +264,7 @@ static const oid_x520_attr_t oid_x520_attr_type[] =
 
 FN_OID_TYPED_FROM_ASN1(oid_x520_attr_t, x520_attr, oid_x520_attr_type)
 FN_OID_GET_ATTR1(mbedtls_oid_get_attr_short_name, oid_x520_attr_t, x520_attr, const char *, short_name)
+#endif /* MBEDTLS_X509_CRT_WRITE_C || !MBEDTLS_X509_REMOVE_INFO */
 
 /*
  * For X509 extensions

--- a/library/x509.c
+++ b/library/x509.c
@@ -951,6 +951,8 @@ static int mbedtls_x509_get_ext( unsigned char **p, const unsigned char *end,
     return( 0 );
 }
 #endif /* defined(MBEDTLS_X509_CRL_PARSE_C) */
+
+#if defined(MBEDTLS_X509_CRT_WRITE_C) || !defined(MBEDTLS_X509_REMOVE_INFO)
 /*
  * Store the name in printable form into buf; no more
  * than size characters will be written
@@ -1012,6 +1014,7 @@ int mbedtls_x509_dn_gets( char *buf, size_t size, const mbedtls_x509_name *dn )
 
     return( (int) ( size - n ) );
 }
+#endif /* MBEDTLS_X509_CRT_WRITE_C || !MBEDTLS_X509_REMOVE_INFO */
 
 /*
  * Store the serial in printable form into buf; no more


### PR DESCRIPTION
Add bunch of ifdefs to help ARMC5's linker to remove unused code from oid.c. On our L0/L4 devices, this reduces the size of oid.o from 1153 to 468 bytes.


## Status
**READY**

## Requires Backporting

NO  

## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.

Build size changes can be observed on Mbed OS uARM builds with feedback files.